### PR TITLE
Fix card overlap issue in blackjack game

### DIFF
--- a/components/hand.py
+++ b/components/hand.py
@@ -3,7 +3,7 @@ from config import *
 
 class Hand():
     def __init__(self, cards, x, y, windowSurface, basicFont):
-        self.cards = [Card(card, x + CARD_OFFSET, y, windowSurface, basicFont) for (i, card) in enumerate(cards)]
+        self.cards = [Card(card, x + i * CARD_OFFSET, y, windowSurface, basicFont) for (i, card) in enumerate(cards)]
         self.x = x
         self.y = y
         self.windowSurface = windowSurface
@@ -13,4 +13,3 @@ class Hand():
     def draw(self):
         for card in self.cards:
             card.draw()
-            


### PR DESCRIPTION
Related to #3

Fix the overlapping of cards in the dealer and player hands by using the offset.

* Multiply `CARD_OFFSET` by the index of the card in the list comprehension in the `Hand` class constructor in `components/hand.py`.
* Update the `x` coordinate of each card to prevent overlapping.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/redblacktree/blackjack/issues/3?shareId=045dd468-1a71-4283-876b-91bf121407ff).