### PR TITLE
Hide dealer hole card

### DIFF
--- a/components/card.py
+++ b/components/card.py
@@ -4,7 +4,7 @@ import requests
 from config import *
 
 class Card():
-    def __init__(self, card, x, y, windowSurface, basicFont):
+    def __init__(self, card, x, y, windowSurface, basicFont, hidden=False):
         self.card = card
         self.x = x
         self.y = y        
@@ -12,6 +12,7 @@ class Card():
         self.card_image = pygame.image.load(self.get_image_from_url(self.card['image']), namehint)
         self.windowSurface = windowSurface
         self.basicFont = basicFont
+        self.hidden = hidden
 
     def get_image_from_url(self, url):
         with (open(os.path.join(os.path.dirname(__file__), 'temp.png'), 'wb')) as f:
@@ -19,7 +20,11 @@ class Card():
         return os.path.join(os.path.dirname(__file__), 'temp.png')
 
     def draw(self):
-        cardRect = self.card_image.get_rect()
+        if self.hidden:
+            card_back_image = pygame.image.load(os.path.join(os.path.dirname(__file__), 'card_back.png'))
+            cardRect = card_back_image.get_rect()
+        else:
+            cardRect = self.card_image.get_rect()
         cardRect.centerx = self.x
         cardRect.centery = self.y
-        self.windowSurface.blit(self.card_image, cardRect)
+        self.windowSurface.blit(self.card_image if not self.hidden else card_back_image, cardRect)

--- a/components/card.py
+++ b/components/card.py
@@ -19,9 +19,15 @@ class Card():
             f.write(requests.get(url).content)
         return os.path.join(os.path.dirname(__file__), 'temp.png')
 
+    def get_card_back_image(self):
+        url = 'https://deckofcardsapi.com/static/img/back.png'
+        with (open(os.path.join(os.path.dirname(__file__), 'temp_back.png'), 'wb')) as f:
+            f.write(requests.get(url).content)
+        return os.path.join(os.path.dirname(__file__), 'temp_back.png')
+
     def draw(self):
         if self.hidden:
-            card_back_image = pygame.image.load(os.path.join(os.path.dirname(__file__), 'card_back.png'))
+            card_back_image = pygame.image.load(self.get_card_back_image())
             cardRect = card_back_image.get_rect()
         else:
             cardRect = self.card_image.get_rect()

--- a/components/hand.py
+++ b/components/hand.py
@@ -2,8 +2,8 @@ from components.card import Card
 from config import *
 
 class Hand():
-    def __init__(self, cards, x, y, windowSurface, basicFont):
-        self.cards = [Card(card, x + i * CARD_OFFSET, y, windowSurface, basicFont) for (i, card) in enumerate(cards)]
+    def __init__(self, cards, x, y, windowSurface, basicFont, hide_first_card=False):
+        self.cards = [Card(card, x + i * CARD_OFFSET, y, windowSurface, basicFont, hidden=(hide_first_card and i == 0)) for (i, card) in enumerate(cards)]
         self.x = x
         self.y = y
         self.windowSurface = windowSurface

--- a/scenes/game.py
+++ b/scenes/game.py
@@ -14,7 +14,7 @@ class GameScene():
 
     def draw(self):
         self.windowSurface.fill(WHITE)
-        self.dealer_hand = Hand(cards=self.game_state.dealer_hand['cards'], x=DEALER_CARDS_X, y=DEALER_CARDS_Y, windowSurface=self.windowSurface, basicFont=self.basicFont)
+        self.dealer_hand = Hand(cards=self.game_state.dealer_hand['cards'], x=DEALER_CARDS_X, y=DEALER_CARDS_Y, windowSurface=self.windowSurface, basicFont=self.basicFont, hide_first_card=True)
         self.player_hand = Hand(cards=self.game_state.player_hand['cards'], x=PLAYER_CARDS_X, y=PLAYER_CARDS_Y, windowSurface=self.windowSurface, basicFont=self.basicFont)
         [x.draw(self.windowSurface) for x in self.buttons]
         self.dealer_hand.draw()


### PR DESCRIPTION
Related to #8

Hide the dealer's hole card when hands are dealt.

* **components/card.py**
  - Add a `hidden` attribute to the `Card` class to indicate if the card should be hidden.
  - Modify the `Card` class's `draw` method to draw a card back image if the card is hidden.
* **components/hand.py**
  - Add an optional `hide_first_card` parameter to the `Hand` class to hide the first card.
  - Modify the `Hand` class's `draw` method to hide the first card if `hide_first_card` is True.
* **scenes/game.py**
  - Pass `hide_first_card=True` when creating the dealer's hand in the `GameScene` class.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/redblacktree/blackjack/issues/8?shareId=8da51e6c-157d-444e-a3f2-41804489e00f).