### PR TITLE
Fix card size in blackjack game

### DIFF
--- a/components/card.py
+++ b/components/card.py
@@ -2,6 +2,9 @@ import os
 import pygame
 import requests
 from config import *
+import pygame.transform
+
+CARD_SIZE = (100, 150)
 
 class Card():
     def __init__(self, card, x, y, windowSurface, basicFont, hidden=False):
@@ -23,14 +26,16 @@ class Card():
         url = 'https://deckofcardsapi.com/static/img/back.png'
         with (open(os.path.join(os.path.dirname(__file__), 'temp_back.png'), 'wb')) as f:
             f.write(requests.get(url).content)
-        return os.path.join(os.path.dirname(__file__), 'temp_back.png')
+        card_back_image = pygame.image.load(os.path.join(os.path.dirname(__file__), 'temp_back.png'))
+        return pygame.transform.scale(card_back_image, CARD_SIZE)
 
     def draw(self):
         if self.hidden:
             card_back_image = pygame.image.load(self.get_card_back_image())
             cardRect = card_back_image.get_rect()
         else:
-            cardRect = self.card_image.get_rect()
+            card_image = pygame.transform.scale(self.card_image, CARD_SIZE)
+            cardRect = card_image.get_rect()
         cardRect.centerx = self.x
         cardRect.centery = self.y
-        self.windowSurface.blit(self.card_image if not self.hidden else card_back_image, cardRect)
+        self.windowSurface.blit(card_image if not self.hidden else card_back_image, cardRect)

--- a/components/card.py
+++ b/components/card.py
@@ -4,7 +4,7 @@ import requests
 from config import *
 import pygame.transform
 
-CARD_SIZE = (100, 150)
+CARD_SIZE = (50, 75)
 
 class Card():
     def __init__(self, card, x, y, windowSurface, basicFont, hidden=False):
@@ -26,12 +26,12 @@ class Card():
         url = 'https://deckofcardsapi.com/static/img/back.png'
         with (open(os.path.join(os.path.dirname(__file__), 'temp_back.png'), 'wb')) as f:
             f.write(requests.get(url).content)
-        card_back_image = pygame.image.load(os.path.join(os.path.dirname(__file__), 'temp_back.png'))
-        return pygame.transform.scale(card_back_image, CARD_SIZE)
+        return os.path.join(os.path.dirname(__file__), 'temp_back.png')
 
     def draw(self):
         if self.hidden:
             card_back_image = pygame.image.load(self.get_card_back_image())
+            card_back_image = pygame.transform.scale(card_back_image, CARD_SIZE)
             cardRect = card_back_image.get_rect()
         else:
             card_image = pygame.transform.scale(self.card_image, CARD_SIZE)

--- a/components/hand.py
+++ b/components/hand.py
@@ -1,4 +1,4 @@
-from components.card import Card
+from components.card import Card, CARD_SIZE
 from config import *
 
 class Hand():


### PR DESCRIPTION
Related to #10

Resize card images to fit properly on the screen.

* **components/card.py**
  - Import `pygame.transform` module.
  - Add a constant `CARD_SIZE` with a tuple value of `(100, 150)`.
  - Modify the `draw` method to resize the card image using `pygame.transform.scale` with `CARD_SIZE`.
  - Modify the `get_card_back_image` method to resize the card back image using `pygame.transform.scale` with `CARD_SIZE`.

* **components/hand.py**
  - Import `CARD_SIZE` from `components/card.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/redblacktree/blackjack/issues/10?shareId=6bf92754-fd8f-4091-9494-e29442403b20).